### PR TITLE
added process.hrtime([time])

### DIFF
--- a/src/low_native.cpp
+++ b/src/low_native.cpp
@@ -16,6 +16,7 @@
 duk_function_list_entry g_low_native_methods[] = {
     {"processInfo", low_process_info, 2},
     {"ttyInfo", low_tty_info, 0},
+    {"hrtime", low_hrtime, 1},
     {"compile", low_compile, 1},
     {"runInContext", low_run_in_context, 4},
     {"compare", low_compare, 2},

--- a/src/low_process.h
+++ b/src/low_process.h
@@ -9,5 +9,6 @@
 
 duk_ret_t low_process_info(duk_context *ctx);
 duk_ret_t low_tty_info(duk_context *ctx);
+duk_ret_t low_hrtime(duk_context *ctx);
 
 #endif /* __LOW_PROCESS_H__ */


### PR DESCRIPTION
On Linux x64 behavior is consistent with node.js. Please check if ESP32 & Mac OS parts are implemented correctly, as they were not tested.