### PR TITLE
Simplify instructions for cloning with submodules

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,8 @@ With this software installed, please install pyyaml with pip:
 
 The compilation itself can be done with these commands:
 
-    git clone https://github.com/neonious/lowjs
+    git clone --recurse-submodules https://github.com/neonious/lowjs
     cd lowjs
-    git submodule update --init --recursive
     make
 
 low.js is now built in bin and can be called via bin/low.


### PR DESCRIPTION
`--recurse-submodules` can be used in the initial `git clone` instruction to automatically initialize and clone submodules.

See: https://www.git-scm.com/docs/git-clone#git-clone---recurse-submodulesltpathspec