### PR TITLE
Allow to redefine lib path

### DIFF
--- a/app/low_config.h
+++ b/app/low_config.h
@@ -25,4 +25,8 @@
 
 #define LOW_ESP32_LWIP_SPECIALITIES 0
 
+#ifndef LOW_LIB_PATH
+#define LOW_LIB_PATH "../lib/"
+#endif
+
 #endif /* __LOW_CONFIG_H__ */

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -37,7 +37,7 @@ static void handle_dist_loader(int *argc, char ***argv)
 	if(*argc < 2)
 		return;
 
-	const char postfix[] = "../lib/low-exe";
+	const char postfix[] = LOW_LIB_PATH "/low-exe";
 	int len = strlen((*argv)[0]);
 	if(len < sizeof(postfix) || strcmp((*argv)[0] + len - (sizeof(postfix) - 1), postfix) != 0)
 		return;

--- a/src/low_system.cpp
+++ b/src/low_system.cpp
@@ -129,7 +129,7 @@ bool low_system_init(int argc, const char *argv[])
 
     g_low_system.lib_path = NULL;
 
-    const char lib_add_path[] = "../lib/";
+    const char lib_add_path[] = LOW_LIB_PATH;
     int lib_add_path_len = sizeof(lib_add_path) - 1;
 
 #ifdef __APPLE__


### PR DESCRIPTION
This is mainly for distributions, to allow FHS-compliance (`/usr/bin/low`, `/usr/lib/low/*.low`).