### PR TITLE
Hardcoded os.tmpdir to /tmp for linux platform

### DIFF
--- a/lib_js/os.js
+++ b/lib_js/os.js
@@ -33,11 +33,10 @@ export function homedir() {
 }
 
 export function tmpdir() {
-    switch(process.platform) {
-        case "linux":
-            return "/tmp";
-        default:
-            return "/";
+    if (process.platform == 'esp32') {
+        return "/";
+    } else {
+        return "/tmp";
     }
 }
 

--- a/lib_js/os.js
+++ b/lib_js/os.js
@@ -33,7 +33,12 @@ export function homedir() {
 }
 
 export function tmpdir() {
-    return "/";
+    switch(process.platform) {
+        case "linux":
+            return "/tmp";
+        default:
+            return "/";
+    }
 }
 
 export function hostname() {


### PR DESCRIPTION
While this still isn't a proper implementation, it's at least better than defaulting to `/` and breaking unless we're root.