### PR TITLE
Implemented process.umask

### DIFF
--- a/src/low_process.cpp
+++ b/src/low_process.cpp
@@ -167,6 +167,18 @@ static duk_ret_t low_process_chdir(duk_context *ctx)
 
     return 0;
 }
+
+// -----------------------------------------------------------------------------
+//  low_process_umask
+// -----------------------------------------------------------------------------
+
+static duk_ret_t low_process_umask(duk_context *ctx)
+{
+    //Since there is no method to set the umask, we can always return the default
+    duk_push_int(ctx, 0);
+    return 1;
+}
+
 /*
 // -----------------------------------------------------------------------------
 //  low_process_memoryUsage
@@ -313,6 +325,8 @@ duk_ret_t low_process_info(duk_context *ctx)
     duk_put_prop_string(ctx, 0, "chdir");
     duk_push_c_function(ctx, low_call_next_tick_js, DUK_VARARGS);
     duk_put_prop_string(ctx, 0, "nextTick");
+    duk_push_c_function(ctx, low_process_umask, 0); //Deprecated in node v14
+    duk_put_prop_string(ctx, 0, "umask");
     //    duk_push_c_function(ctx, low_process_memoryUsage, 0);
     //    duk_put_prop_string(ctx, 0, "memoryUsage");
 


### PR DESCRIPTION
There are still libraries that rely on this recently deprecated functionality.

`mkdirp` for example which is a dependency of the expressjs middleware `multer` which handles multi-part form uploads