### PR TITLE
Implemented ServerResponse._implicitHeader

### DIFF
--- a/lib_js/internal/http.js
+++ b/lib_js/internal/http.js
@@ -314,6 +314,10 @@ class ServerResponse extends stream.Writable {
         native.httpWriteHead(this.connection._socketFD, headersAsTxt, len, chunked);
     }
 
+    _implicitHeader() {
+        return this.writeHead(this.statusCode);
+    }
+
     setHeader(name, value) {
         if (this.headersSent)
             return;


### PR DESCRIPTION
`expressjs/compression` is using this undocumented feature.

https://github.com/nodejs/node/blob/8a6fab02adab2de05f6e864847f96b0924be0840/lib/_http_server.js#L243

Since the goal is to be API-compatible, low.js should also implement that.

https://github.com/expressjs/compression/pull/128
The PR doesn't look like this is going to change anytime soon.

This is of course rather pointless at this stage since there's no zlib module in low.js yet